### PR TITLE
Add support for Windows

### DIFF
--- a/flask_now/now.py
+++ b/flask_now/now.py
@@ -12,25 +12,12 @@ def main():
     parser.add_argument('name', help='Name of your project', type=str)
     parser.add_argument('type', help='Type of project: Either Simple or Blueprints: (simple or bp)', type=str)
     parser.add_argument('-e', '--extensions', help='list of extensions', nargs='+')
-    parser.add_argument('-p', '--python', help='Global python3 path', default='python3')
+    parser.add_argument('-p', '--python', help='Global python3 path', default=sys.executable)
 
     args = parser.parse_args()
-    global_python = args.python
-    if args.python == 'python3' and os.name != 'nt':
-        process = subprocess.Popen(['which', 'python3'], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        out, err = process.communicate()
-        code = process.returncode
-        if code == 0:
-            global_python = out.decode("utf-8")
-            global_python = global_python.replace('\n', ' ')
-        else:
-            raise Exception('No python path supplied: {}'.format(err))
-    elif args.python == 'python3' and os.name == 'nt':
-        global_python = sys.executable
 
     create_example_app(args.name, args.type)
-    create_venv(global_python)
+    create_venv(args.python)
     create_requirements(args.extensions)
     install_extensions()
 


### PR DESCRIPTION
This pull request makes flask-now work on Windows.

![Animation showing flask-now running on Windows](https://user-images.githubusercontent.com/1086421/66273622-7848ca80-e843-11e9-8a08-65e3be805003.gif)

This required two minor fixes:

- The `which` utility doesn't exist on Windows which leads to a FileNotFoundError when trying to look up the path of the Python binary. This change adds a fallback to [sys.executable](https://docs.python.org/3/library/sys.html#sys.executable) which fixes the problem (as long as we can assume that the Python interpreter used to run flask-now is a valid Python3 interpreter).

- The path to the pip executable in a virtual environment is different on Windows than Unix which leads to a FileNotFoundError. This change adds a check to [os.name](https://docs.python.org/3/library/os.html#os.name) to adjust the pip path if flask-now is being run on Windows.